### PR TITLE
Batch merge dependabot updates

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
       uses: pnpm/action-setup@v6
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           cache: 'pnpm'


### PR DESCRIPTION
This PR merges all dependabot dependency updates in a single batch.

## Included Updates
- **#75**: chore(deps): bump actions/setup-node from 6 to 7 in the github-actions group

All conflicts have been resolved and the build passes.